### PR TITLE
Fixed clang template issue and changed flags for Clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,16 +16,16 @@ MESSAGE ( STATUS "Host system is " ${CMAKE_HOST_SYSTEM} " with processor " ${CMA
 MESSAGE ( STATUS "Target system is " ${CMAKE_SYSTEM} " with processor " ${CMAKE_SYSTEM_PROCESSOR} )
 
 # Whether to build alice-addon
-OPTION (BUILD_ADDON "Build addon library (optional but useful)" OFF) 
+OPTION (BUILD_ADDON "Build addon library (optional but useful)" OFF)
 
 # Build documentation
-OPTION (BUILD_DOCUMENTATION "Generate API documentation" OFF) 
+OPTION (BUILD_DOCUMENTATION "Generate API documentation" OFF)
 
 # Build examples
-OPTION (BUILD_EXAMPLE "Build example code" OFF) 
+OPTION (BUILD_EXAMPLE "Build example code" OFF)
 
 # Build unit tests
-OPTION (BUILD_TEST "Build unit tests, requires Boost.Test library" OFF) 
+OPTION (BUILD_TEST "Build unit tests, requires Boost.Test library" OFF)
 
 #------------------------------------------------------------
 # Version Info
@@ -45,7 +45,7 @@ ENDIF ( CMAKE_SYSTEM_NAME STREQUAL "Linux" )
 #------------------------------------------------------------
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  ADD_DEFINITIONS ( "-O3 --std=c++0x --stdlib=c++ -fPIC" )
+  ADD_DEFINITIONS ( "-O3 --std=c++0x -fPIC -Wall -Wno-sign-compare -Wno-unused-variable" )
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   ADD_DEFINITIONS ( "-O3 --std=c++0x -fPIC -Wall -Wno-sign-compare -Wno-unused-variable" )
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
@@ -72,21 +72,21 @@ IF ( UNIX )
     # Protocol Buffers
     find_package( Protobuf REQUIRED )
     include_directories( ${PROTOBUF_INCLUDE_DIR} )
-    SET ( PROTOC "protoc" ) 
-    
+    SET ( PROTOC "protoc" )
+
     # Snappy
     include ( FindSnappy )
     find_package ( Snappy REQUIRED )
     include_directories( ${SNAPPY_INCLUDE_DIR} )
     SET ( SNAPPY_SOURCES "" )
-    
-    # Boost headers / librarys 
+
+    # Boost headers / librarys
     IF ( BUILD_TEST )
         find_package (Boost COMPONENTS system unit_test_framework REQUIRED)
     ELSE ( BUILD_TEST )
         find_package ( Boost REQUIRED )
     ENDIF ( BUILD_TEST )
-    
+
     include_directories( ${Boost_INCLUDE_DIRS} )
 ELSE ( UNIX )
     # Protobuf
@@ -95,10 +95,10 @@ ELSE ( UNIX )
         SET ( CMAKE_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/deps/protobuf-2.5.0/vsprojects/Release )
         SET ( PROTOC ${CMAKE_SOURCE_DIR}/deps/protobuf-2.5.0/vsprojects/Release/protoc.exe )
     ENDIF ( EXISTS ${CMAKE_SOURCE_DIR}/deps/protobuf-2.5.0/vsprojects/Release )
-    
+
     find_package( Protobuf REQUIRED )
     include_directories( ${PROTOBUF_INCLUDE_DIR} )
-    
+
     # Snappy
     IF ( EXISTS ${CMAKE_SOURCE_DIR}/deps/snappy-1.1.1/ )
 		# just build snappy with the project on windows
@@ -108,18 +108,18 @@ ELSE ( UNIX )
 	ELSE ( EXISTS ${CMAKE_SOURCE_DIR}/deps/snappy-1.1.1/ )
 		MESSAGE ( error "Can't find snappy" )
     ENDIF ( EXISTS ${CMAKE_SOURCE_DIR}/deps/snappy-1.1.1/ )
-    
-    # Boost headers / librarys 
+
+    # Boost headers / librarys
     IF ( EXISTS ${CMAKE_SOURCE_DIR}/deps/boost-1.55.0 )
         SET ( BOOST_ROOT ${CMAKE_SOURCE_DIR}/deps/boost-1.55.0 )
     ENDIF ( EXISTS ${CMAKE_SOURCE_DIR}/deps/boost-1.55.0 )
-    
+
     IF ( BUILD_TEST )
         find_package (Boost COMPONENTS system unit_test_framework REQUIRED)
     ELSE ( BUILD_TEST )
         find_package ( Boost REQUIRED )
     ENDIF ( BUILD_TEST )
-    
+
     include_directories( ${Boost_INCLUDE_DIRS} )
 ENDIF ( UNIX )
 
@@ -130,7 +130,7 @@ include_directories( ${CMAKE_SOURCE_DIR}/src )
 #------------------------------------------------------------
 
 FILE( GLOB ProtoFiles ${CMAKE_SOURCE_DIR}/proto/*.proto )
-EXECUTE_PROCESS ( COMMAND ${PROTOC} 
+EXECUTE_PROCESS ( COMMAND ${PROTOC}
     ${ProtoFiles}
     --cpp_out=${CMAKE_SOURCE_DIR}/src
     --proto_path=${CMAKE_SOURCE_DIR}/proto
@@ -151,9 +151,9 @@ SET ( PROTO_SOURCES
     src/usermessages.pb.cc
 )
 
-SET ( ALICE_CORE_SOURCES 
-    src/bitstream.cpp 
-    src/entity.cpp 
+SET ( ALICE_CORE_SOURCES
+    src/bitstream.cpp
+    src/entity.cpp
     src/gamestate.cpp
     src/property.cpp
     src/reader.cpp
@@ -246,14 +246,14 @@ IF ( BUILD_EXAMPLE )
     ADD_EXECUTABLE ( alice-example
         example/example.cpp
     )
-    
+
     TARGET_LINK_LIBRARIES ( alice-example
         alice-core-static
         ${PROTOBUF_LIBRARY}
     	${SNAPPY_LIBRARIES}
     	${Boost_LIBRARIES}
     )
-    
+
     INSTALL( TARGETS alice-example RUNTIME DESTINATION bin )
 ENDIF ( BUILD_EXAMPLE )
 

--- a/src/handler.hpp
+++ b/src/handler.hpp
@@ -10,7 +10,7 @@
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,20 +26,20 @@
 #include <unordered_map>
 #include <vector>
 #include <utility>
-#include <memory>    
+#include <memory>
 #include <type_traits>
 
 #include <google/protobuf/message.h>
-    
+
 #include "entity.hpp"
 #include "exception.hpp"
 #include "delegate.hpp"
 
-/// Registers and object with the handler. 
+/// Registers and object with the handler.
 ///
-/// Invoking it is nessecary when the object should be created by the handler from the data 
+/// Invoking it is nessecary when the object should be created by the handler from the data
 /// supplied (e.g. create a protobuffer from a string).
-/// If the above is the case, the object supplied as the 3rd parameter is constructed and its 
+/// If the above is the case, the object supplied as the 3rd parameter is constructed and its
 /// parseFromString function is invoked on the data.
 ///
 /// Example: handlerRegisterObject( handler, msgTest, 0, MyProtobuf )
@@ -49,10 +49,10 @@ handler_->registerObject<type_, object_>( (handler_t::type<type_>::id_t) id_ );
 
 /// Register a callback function for specified type.
 ///
-/// The callback is invoked when an object is relayed to the handler with the specified unique 
-/// and non-unique identifier. The macro can only be called from the class having the callback 
+/// The callback is invoked when an object is relayed to the handler with the specified unique
+/// and non-unique identifier. The macro can only be called from the class having the callback
 /// function as the delegate is constructed explicitly from *this;
-/// 
+///
 /// Example: handlerRegisterCallback( handler, msgTest, 0, myObject, myFunction )
 ///
 #define handlerRegisterCallback(handler_, type_, id_, object_, function_) \
@@ -66,7 +66,7 @@ handler_->registerCallback<type_>( \
 /// This macro removes a callback function which has been registered with handlerRegisterCallback.
 /// Parameter order and usage is the same. Removing should only be done in special cases when you
 /// realy don't rely on the object anymore as iterating the whole callback list is required.
-/// 
+///
 /// Example: handlerRemoveCallback( handler, msgTest, 0, myObject, myFunction )
 ///
 #define handlerRemoveCallback(handler_, type_, id_, object_, function_) \
@@ -115,29 +115,29 @@ handler_->removeCallback<type_>( \
 namespace dota {
     /// @defgroup EXCEPTIONS Exceptions
     /// @{
-    
+
     /// Gets thrown when an unkown subhandler type is specified.
     ///
     /// An important think to look into when this is thrown is whether the type of said
     /// subhandler is passed as uint32_t.
     CREATE_EXCEPTION( handlerNoConversionAvailable, "Unable to convert base-id to unique message-id." )
-    
+
     /// Gets thrown when protobuf fails to parse the message
     CREATE_EXCEPTION( handlerParserError, "Error while parsing message with protobuf" )
-    
+
     /// Gets thrown when the conversion from data to object fails
     ///
     /// This likely happens when you subscribe to a type which is available in the protobuf fails
     /// but is missing acorresponding #handlerRegisterObject call.
     CREATE_EXCEPTION( handlerTypeError, "Type in question has not be registered." )
-    
+
     /// Thrown when anything but std::string is handled in a prefix context.
     CREATE_EXCEPTION( handlerPrefixError, "Type in question is unabled to be used in the prefix context." )
-    
+
     /// @}
     /// @defgroup CORE Core
     /// @{
-    
+
     /** Callback object getting supplied to each function invoked by the handler. */
     template <typename Obj, typename Id>
     struct cbObject {
@@ -149,30 +149,30 @@ namespace dota {
         const Id &id;
         /** Whether to take ownership of the memory */
         bool ownsPointer;
-        
+
         /** Constructor, sets all values */
-        cbObject(Obj msg, uint32_t tick, const Id &id, bool ownsPointer = true) 
+        cbObject(Obj msg, uint32_t tick, const Id &id, bool ownsPointer = true)
             : tick(tick), msg(std::move(msg)), id(id), ownsPointer(ownsPointer) { }
-        
+
         /** Destructor, deletes message if it's a pointer */
-        ~cbObject() { 
+        ~cbObject() {
             if (ownsPointer)
                 detail::destroyCallbackObjectHelper<Obj>::destroy(std::move(msg));
         }
-        
+
         /** Casts message into the specified type and returns it. */
         template <typename T>
         T* get() {
             return reinterpret_cast<T*>(msg);
         }
     };
-    
-    /** 
-     * Used to transmit string data and length to the handler. 
-     * 
+
+    /**
+     * Used to transmit string data and length to the handler.
+     *
      * Taking substrings of std::string always requires a copy. This is generally pretty bad
      * for the performance because most of the messages are nested. This struct is a compromise
-     * between adding a pointer + size as handler argument and using the std::string. It's not as 
+     * between adding a pointer + size as handler argument and using the std::string. It's not as
      * nice but it's still viable and leads to a significant performance increase.
      */
     struct stringWrapper {
@@ -181,36 +181,36 @@ namespace dota {
         /** size to read */
         std::size_t size;
     };
-    
-    /** 
-     * This is the implementation of each of the handler functions for a specifc set of parameters. 
-     * 
+
+    /**
+     * This is the implementation of each of the handler functions for a specifc set of parameters.
+     *
      * @param Obj Parent object for each of the messages that should be parsed
      * @param Id Which type non-unique ID's should be saved at (e.g. uint32_t, string)
      * @param Data Type of the data that should be parsed into Obj
      * @param Own unique ID in the handler context (numeric uint32_t)
     */
-    template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+    template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
     class handlersub {
         public:
             /** Type for parent object each message of this type inherits from */
             typedef Obj obj_t;
             /** Type of the object id to manage relations */
             typedef Id id_t;
-            
+
             /** Type for the parameter of the callback function */
             typedef cbObject<Obj, Id>* callbackObj_t;
             /** Type for the callback signature */
             typedef delegate<void, callbackObj_t> delegate_t;
-            
+
             /** Own unique ID in the handler context */
             static const unsigned id = IdSelf;
-            
+
             /** Returns true if the specified type has at least one callback function */
             bool hasCallback(const id_t& i) {
                 return hasCallback(i, std::is_same<std::string, Id>{});
             }
-            
+
             /** Registers a new callback handler for the specified ID */
             void registerCallback(const id_t& i, delegate_t&& d, bool prefix = false) {
                 if (prefix && std::is_same<std::string, Id>::value) {
@@ -220,11 +220,11 @@ namespace dota {
                     cb[i].push_back(std::move(d));
                 }
             }
-            
-            /** 
+
+            /**
              * Removes a callback handler for the specified ID.
-             * 
-             * This function is relativly expensive when a lot of handlers are registered because it 
+             *
+             * This function is relativly expensive when a lot of handlers are registered because it
              * has to iterate over the complete handler. Removing callbacks is generally not nessecary
              * so this function should not be overused.
              */
@@ -245,24 +245,24 @@ namespace dota {
                     }
                 }
             }
-            
+
             /** Register a new object type for the specified ID */
             template <typename T>
             void registerObject(const id_t& i) {
                 obj[i] = [](stringWrapper&& data) {
-                    obj_t msg = new T;                        
+                    obj_t msg = new T;
                     if (!msg->ParseFromArray(data.str, data.size))
                             BOOST_THROW_EXCEPTION((handlerParserError()));
-                            
+
                     return msg;
                 };
             }
-            
+
             /** Forwards a message to all handlers, the correct object is inferred from the id. */
             void forward(const id_t& i, Data&& data, uint32_t tick) {
                 forward(i, std::move(data), tick, std::is_same<Obj, Data>{});
             }
-            
+
             /** Deletes all registered callbacks and objects. */
             void clear() {
                 cb.clear();
@@ -274,24 +274,24 @@ namespace dota {
             typedef std::unordered_map<id_t, std::vector<delegate_t>> cbmap_t;
             /** Callback list */
             cbmap_t cb;
-            
+
             /** Type for a list of registered objects */
             typedef std::unordered_map<id_t, obj_t (*)(Data&&)> objmap_t;
             /** Object list */
             objmap_t obj;
             /** List of prefix searched objects when dealing with string ids */
             cbmap_t cbpref;
-            
+
             /** Called if prefix serarch is applicable */
             bool hasCallback(const id_t& i, std::true_type);
             /** Called if id needs to be equal to cb */
             bool hasCallback(const id_t& i, std::false_type);
-            
+
             /** Called if the message needs to be parsed from the data */
             void forward(const id_t& i, Data &&data, uint32_t tick, std::false_type);
             /** Called if the data is already in message format */
             void forward(const id_t& i, Data &&data, uint32_t tick, std::true_type);
-            
+
             /** Forward a message to all handlers matching the prefix */
             void forwardPrefix(callbackObj_t o) {
                 forwardPrefix(o, std::is_same<std::string, Id>{});
@@ -301,152 +301,152 @@ namespace dota {
             /** Forward a message to all handlers matching the prefix, stub, throws */
             void forwardPrefix(callbackObj_t o, std::false_type);
     };
- 
-    /** 
-     * Handler, taking a variable number of subhandlers and handles functions accordingly. 
-     * 
+
+    /**
+     * Handler, taking a variable number of subhandlers and handles functions accordingly.
+     *
      * This class is implemented as a variadic template. This saves us the time of using a parent-child construct
      * which requires virtual method and can't be optimized well. The handler calls get inlined at compile time which
      * makes this method a lot faster.
      */
     template <typename...>
     class handler;
-    
+
     template <>
     class handler<> {
-        public:        
+        public:
             template <uint32_t Type, typename Id>
             bool hasCallback(const Id& i) {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
-                
+
                 return false; // just to fix compiler warnings
             }
-        
+
             template<uint32_t Type, typename Id, typename Delegate>
             void registerCallback(const Id& i, Delegate&& d, bool prefix = false) {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
             }
-            
+
             template<uint32_t Type, typename Id, typename Delegate>
             void removeCallback(const Id& i, Delegate&& d, bool prefix = false) {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
             }
-            
+
             template<uint32_t Type, typename T, typename Id>
             void registerObject(const Id& i) {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
             }
-            
+
             template <uint32_t Type, typename Id, typename Data>
             void forward(const Id& i, Data &&data, uint32_t tick) {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
             }
-            
+
             template <uint32_t Type>
             void clear() {
                 BOOST_THROW_EXCEPTION(handlerTypeError()
                     << (EArgT<1, uint32_t>::info(Type))
                 );
             }
-    };    
-    
+    };
+
     template <typename T1, typename... Rest>
     class handler<T1, Rest...> {
         public:
             /** Helper to get the type for the Nth argument. */
             template <unsigned int N>
             using type = typename detail::GetNthArgument<N, T1, Rest...>::type;
-            
+
             /** Returns true if a callback function for the specified ID is available. */
             template <uint32_t Type, typename Id>
             bool hasCallback(const Id& i) {
                 return hasCallback<Type, Id>(i, std::is_same<typename T1::id_t, Id>{});
             }
-        
+
             /** Register a callback for a specified type */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void registerCallback(const Id& i, Delegate&& d, bool prefix = false) {
                 registerCallback<Type, Id, Delegate>(i, std::move(d), prefix, std::is_same<typename T1::id_t, Id>{});
             }
-            
+
             /** Removes a callback for a specified type */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void removeCallback(const Id& i, Delegate&& d, bool prefix = false) {
                 removeCallback<Type, Id, Delegate>(i, std::move(d), prefix, std::is_same<typename T1::id_t, Id>{});
             }
-            
+
             /** Register an object for a specific ID of the selected type */
-            template<uint32_t Type, typename T, typename Id> 
+            template<uint32_t Type, typename T, typename Id>
             void registerObject(const Id& i) {
                 registerObject<Type, T, Id>(i, std::is_same<typename T1::id_t, Id>{});
             }
-            
+
             /** Forwards a message to all registered handlers */
             template <uint32_t Type, typename Id, typename Data>
             void forward(Id i, Data data, uint32_t tick) {
                 forward<Type, Id, Data>(std::move(i), std::move(data), tick, std::is_same<typename T1::id_t, Id>{});
             }
-            
+
             /** Removes all registered callbacks */
             template <uint32_t Type>
             void clear() {
                 if (T1::id == Type) {
                     subhandler.clear();
                 } else {
-                    child.clear<Type>();
+                    child.template clear<Type>();
                 }
             }
         private:
-            /** 
+            /**
              * The current subhandler.
-             * 
+             *
              * Each recursion has it's own subhandler as a member variable. This is required if
              * we want the handler state to depend soley on the object refered to as opposed to
              * having global instances.
              */
             T1 subhandler;
-            
+
             /** The next handler in the recursion process. */
             handler<Rest...> child;
-        
+
             /** Implementation for hasCallback */
             template <uint32_t Type, typename Id>
             bool hasCallback(const Id& i, std::true_type);
             /** Implementation for hasCallback */
             template <uint32_t Type, typename Id>
             bool hasCallback(const Id& i, std::false_type);
-            
+
             /** Implementation for registerCallback */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void registerCallback(const Id& i, Delegate&& d, bool prefix, std::true_type);
             /** Implementation for registerCallback */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void registerCallback(const Id& i, Delegate&& d, bool prefix, std::false_type);
-            
+
             /** Implementation for removeCallback */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void removeCallback(const Id& i, Delegate&& d, bool prefix, std::true_type);
             /** Implementation for removeCallback */
-            template<uint32_t Type, typename Id, typename Delegate> 
+            template<uint32_t Type, typename Id, typename Delegate>
             void removeCallback(const Id& i, Delegate&& d, bool prefix, std::false_type);
-            
+
             /** Implementation for registerObject */
-            template<uint32_t Type, typename T, typename Id> 
+            template<uint32_t Type, typename T, typename Id>
             void registerObject(const Id& i, std::true_type);
             /** Implementation for registerObject */
-            template<uint32_t Type, typename T, typename Id> 
+            template<uint32_t Type, typename T, typename Id>
             void registerObject(const Id& i, std::false_type);
-            
+
             /** Implementation for forward */
             template <uint32_t Type, typename Id, typename Data>
             void forward(Id i, Data data, uint32_t tick, std::true_type);
@@ -455,25 +455,25 @@ namespace dota {
             void forward(Id i, Data data, uint32_t tick, std::false_type);
     };
 
-    // this file includes the actual implementation which is seperated for enhanced readability    
+    // this file includes the actual implementation which is seperated for enhanced readability
     #include "handler_impl.hpp"
-    
+
     /** Enumeration of different message types for our replay parser */
     enum type {
         msgDem = 0, // messages encoded in the dem-file
-        msgUser,    // user messages 
-        msgNet,     // net messages 
-        msgEntity   // entities / deltas of those  
+        msgUser,    // user messages
+        msgNet,     // net messages
+        msgEntity   // entities / deltas of those
     };
-    
+
     /** Type for our default handler */
     typedef handler<
         handlersub< ::google::protobuf::Message*, uint32_t, stringWrapper, msgDem >,
         handlersub< ::google::protobuf::Message*, uint32_t, stringWrapper, msgUser >,
         handlersub< ::google::protobuf::Message*, uint32_t, stringWrapper, msgNet >,
         handlersub< entity*, std::string, entity*, msgEntity >
-    > handler_t;   
-    
+    > handler_t;
+
     /// @}
 }
 

--- a/src/handler_impl.hpp
+++ b/src/handler_impl.hpp
@@ -10,7 +10,7 @@
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,8 +19,8 @@
  *    limitations under the License.
  *
  */
- 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 bool handlersub<Obj, Id, Data, IdSelf>::
 hasCallback(const id_t& i, std::true_type) {
     bool has = (cbpref.find(i) != cbpref.end()) || (cb.find(i) != cb.end());
@@ -28,90 +28,90 @@ hasCallback(const id_t& i, std::true_type) {
         for (auto &d : cbpref) {
             if ((d.first.size() > i.size()) && (i.substr(0, d.first.size()).compare(d.first) != 0))
                 continue;
-                
+
             return true;
         }
     }
-   
+
     return has;
 }
 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 bool handlersub<Obj, Id, Data, IdSelf>::
 hasCallback(const id_t& i, std::false_type) {
     return cb.find(i) != cb.end();
 }
- 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 void handlersub<Obj, Id, Data, IdSelf>::
 forward(const id_t& i, Data &&data, uint32_t tick, std::false_type) {
     auto cbDef = cb.find(i); // check for 1 = 1 callback type
-    
+
     if ((cbDef == cb.end()) && cbpref.empty()) {
         // there is neither a direct callback nor a potential prefix callback
         return;
     }
-    
+
     auto objConv = obj.find(i); // get conversion object
     if (objConv == obj.end()) {
         BOOST_THROW_EXCEPTION(handlerNoConversionAvailable()
             << (typename EArgT<1, id_t>::info(i))
         );
     }
-    
+
     // create object
     cbObject<Obj, Id> o(objConv->second(std::move(data)), tick, i);
-    
+
      // forward to definitive handlers
     if ((cbDef != cb.end()))
         for (auto &d : cbDef->second) {
             d(&o);
         }
-        
+
     // forward to prefix handlers
     if (!cbpref.empty())
         forwardPrefix(&o);
 }
 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 void handlersub<Obj, Id, Data, IdSelf>::
 forward(const id_t& i, Data &&data, uint32_t tick, std::true_type) {
     auto cbDef = cb.find(i); // check for 1 = 1 callback type
-    
+
     if ((cbDef == cb.end()) && cbpref.empty()) {
         // there is neither a direct callback nor a potential prefix callback
         return;
     }
-    
+
     // create object, moving here makes shared_ptrs impossible TODO fix
     cbObject<Obj, Id> o(std::move(data), tick, i, false);
-    
+
     // forward to definitive handlers
     if ((cbDef != cb.end()))
         for (auto &d : cbDef->second) {
             d(&o);
         }
-    
+
     // forward to prefix handlers
-    if (!cbpref.empty()) 
+    if (!cbpref.empty())
         forwardPrefix(&o);
 }
- 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 void handlersub<Obj, Id, Data, IdSelf>::
 forwardPrefix(callbackObj_t o, std::true_type) {
     const std::string& comp = o->id;
-    
+
     for (auto &d : cbpref) {
         if ((d.first.size() > comp.size()) && (comp.substr(0, d.first.size()).compare(d.first) != 0))
             continue;
-            
+
         for (auto &d2 : d.second)
             d2(o);
     }
 }
 
-template <typename Obj, typename Id, typename Data, uint32_t IdSelf> 
+template <typename Obj, typename Id, typename Data, uint32_t IdSelf>
 void handlersub<Obj, Id, Data, IdSelf>::
 forwardPrefix(callbackObj_t o, std::false_type) {
     BOOST_THROW_EXCEPTION(handlerPrefixError() );
@@ -123,62 +123,62 @@ bool handler<T1, Rest...>::hasCallback(const Id& i, std::true_type) {
     if (T1::id == Type) {
         return subhandler.hasCallback(i);
     } else {
-        return child.hasCallback<Type, Id>(i);
+      return child.template hasCallback<Type, Id>(i);
     }
 }
 
 template <typename T1, typename... Rest>
 template <uint32_t Type, typename Id>
 bool handler<T1, Rest...>::hasCallback(const Id& i, std::false_type) {
-    return child.hasCallback<Type, Id>(i);
+    return child.template hasCallback<Type, Id>(i);
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename Id, typename Delegate> 
+template<uint32_t Type, typename Id, typename Delegate>
 void handler<T1, Rest...>::registerCallback(const Id& i, Delegate&& d, bool prefix, std::true_type) {
     if (T1::id == Type) {
         subhandler.registerCallback(i, std::move(d), prefix);
     } else {
-        child.registerCallback<Type>(i, std::move(d), prefix);
+        child.template registerCallback<Type>(i, std::move(d), prefix);
     }
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename Id, typename Delegate> 
+template<uint32_t Type, typename Id, typename Delegate>
 void handler<T1, Rest...>::registerCallback(const Id& i, Delegate&& d, bool prefix, std::false_type) {
-    child.registerCallback<Type>(i, std::move(d), prefix);
+    child.template registerCallback<Type>(i, std::move(d), prefix);
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename Id, typename Delegate> 
+template<uint32_t Type, typename Id, typename Delegate>
 void handler<T1, Rest...>::removeCallback(const Id& i, Delegate&& d, bool prefix, std::true_type) {
     if (T1::id == Type) {
         subhandler.removeCallback(i, std::move(d), prefix);
     } else {
-        child.removeCallback<Type>(i, std::move(d), prefix);
+        child.template removeCallback<Type>(i, std::move(d), prefix);
     }
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename Id, typename Delegate> 
+template<uint32_t Type, typename Id, typename Delegate>
 void handler<T1, Rest...>::removeCallback(const Id& i, Delegate&& d, bool prefix, std::false_type) {
-    child.removeCallback<Type>(i, std::move(d), prefix);
+    child.template removeCallback<Type>(i, std::move(d), prefix);
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename T, typename Id> 
+template<uint32_t Type, typename T, typename Id>
 void handler<T1, Rest...>::registerObject(const Id& i, std::true_type) {
     if (T1::id == Type) {
         subhandler.template registerObject<T>(i);
     } else {
-        child.registerObject<Type, T>(i);
+        child.template registerObject<Type, T>(i);
     }
 }
 
 template <typename T1, typename... Rest>
-template<uint32_t Type, typename T, typename Id> 
+template<uint32_t Type, typename T, typename Id>
 void handler<T1, Rest...>::registerObject(const Id& i, std::false_type) {
-    child.registerObject<Type, T>(i);
+    child.template registerObject<Type, T>(i);
 }
 
 template <typename T1, typename... Rest>
@@ -187,12 +187,12 @@ void handler<T1, Rest...>::forward(Id i, Data data, uint32_t tick, std::true_typ
     if (T1::id == Type) {
         subhandler.forward(std::move(i), std::move(data), std::move(tick));
     } else {
-        child.forward<Type>(std::move(i), std::move(data), std::move(tick));
+        child.template forward<Type>(std::move(i), std::move(data), std::move(tick));
     }
 }
 
 template <typename T1, typename... Rest>
 template <uint32_t Type, typename Id, typename Data>
 void handler<T1, Rest...>::forward(Id i, Data data, uint32_t tick, std::false_type) {
-	child.forward<Type>(std::move(i), std::move(data), std::move(tick));
+	child.template forward<Type>(std::move(i), std::move(data), std::move(tick));
 }


### PR DESCRIPTION
The diff looks much bigger than it should be: There is whitespace sitting on the ends of like 50% of the lines that is getting killed. (Auto-whitespace removal is a (perhaps bad) environment habit I picked up from work. Speaking of which I strongly recommend enabling it on whatever editor you are using.)

The actual changes are just adjustments to the clang flags and adding "template " to every templated call to one of child's member functions.
